### PR TITLE
Add request logging

### DIFF
--- a/src/config/logging.rs
+++ b/src/config/logging.rs
@@ -1,8 +1,8 @@
 //! Values and utilities related to logging configuration
 
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_core::Level;
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, Registry};
 
@@ -11,22 +11,26 @@ const LOG_FILE_PREFIX: &str = "log";
 const LOG_FILE_DIRECTORY: &str = "./log";
 
 pub fn configure_tracing() -> anyhow::Result<Option<WorkerGuard>> {
-    let mut guard: Option<WorkerGuard> = None;
+    let mut _guard: Option<WorkerGuard> = None;
     let subscriber = Registry::default();
 
     #[cfg(feature = "stream-logging")]
     let subscriber = {
-        let s = subscriber.with(fmt::layer());
-        s
+        let layer = fmt::layer()
+            .event_format(tracing_subscriber::fmt::format().compact())
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE);
+        subscriber.with(layer)
     };
 
     #[cfg(feature = "file-logging")]
     let subscriber = {
         let file_appender = tracing_appender::rolling::hourly(LOG_FILE_PREFIX, LOG_FILE_DIRECTORY);
         let (file_writer, worker_guard) = tracing_appender::non_blocking(file_appender);
-        guard = Some(worker_guard);
-        let s = subscriber.with(fmt::layer().with_writer(file_writer));
-        s
+        _guard = Some(worker_guard);
+        let layer = fmt::layer()
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+            .with_writer(file_writer);
+        subscriber.with(layer)
     };
     let default_level_filter = if cfg!(debug_assertions) {
         LevelFilter::DEBUG
@@ -44,5 +48,5 @@ pub fn configure_tracing() -> anyhow::Result<Option<WorkerGuard>> {
     tracing::subscriber::set_global_default(subscriber)?;
 
     tracing::info!("Set up logging subscriber");
-    Ok(guard)
+    Ok(_guard)
 }

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -23,7 +23,7 @@ pub fn get_port() -> u16 {
     match var(PORT_ENV_VAR) {
         Ok(port) => {
             info!("Using {} as the port since {} is set", port, PORT_ENV_VAR);
-            port.parse().expect(format!("The environment variable {PORT_ENV_VAR} contains an invalid port, please fix or delete it").as_str())
+            port.parse().unwrap_or_else(|_| panic!("The environment variable {PORT_ENV_VAR} contains an invalid port, please fix or delete it"))
         }
         _ => {
             info!("Using {} as the port", DEFAULT_PORT);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ use tracing_actix_web::TracingLogger;
 
 #[get("/")]
 async fn root() -> impl Responder {
-    tracing::info!("Root");
     "I am root"
 }
 


### PR DESCRIPTION
Modifies the tracing formatter to log events when request traces are created or closed, which results in logs of server accesses