### PR TITLE
Fix hostname allocation

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -1,4 +1,4 @@
-use std::env::var;
+use std::{borrow::Cow, env::var};
 use tracing::info;
 
 const HOST_ENV_VAR: &str = "WORMHOLE_HOST";
@@ -6,22 +6,28 @@ const PORT_ENV_VAR: &str = "WORMHOLE_PORT";
 const DEFAULT_HOST: &str = "127.0.0.1";
 const DEFAULT_PORT: u16 = 8080;
 
-pub fn get_host() -> String {
-    if let Ok(host) = var(HOST_ENV_VAR) {
-        info!("Using {} as the host since {} is set", host, HOST_ENV_VAR);
-        host
-    } else {
-        info!("Using {} as the host", DEFAULT_HOST);
-        DEFAULT_HOST.to_owned()
+pub fn get_host() -> Cow<'static, str> {
+    match var(HOST_ENV_VAR) {
+        Ok(host) => {
+            info!("Using {} as the host since {} is set", host, HOST_ENV_VAR);
+            host.into()
+        }
+        _ => {
+            info!("Using {} as the host", DEFAULT_HOST);
+            DEFAULT_HOST.into()
+        }
     }
 }
 
 pub fn get_port() -> u16 {
-    if let Ok(port) = var(PORT_ENV_VAR) {
-        info!("Using {} as the port since {} is set", port, PORT_ENV_VAR);
-        port.parse().expect(format!("The environment variable {PORT_ENV_VAR} contains an invalid port, please fix or delete it").as_str())
-    } else {
-        info!("Using {} as the port", DEFAULT_PORT);
-        DEFAULT_PORT
+    match var(PORT_ENV_VAR) {
+        Ok(port) => {
+            info!("Using {} as the port since {} is set", port, PORT_ENV_VAR);
+            port.parse().expect(format!("The environment variable {PORT_ENV_VAR} contains an invalid port, please fix or delete it").as_str())
+        }
+        _ => {
+            info!("Using {} as the port", DEFAULT_PORT);
+            DEFAULT_PORT
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,10 @@ async fn main() -> AnyhowResult<()> {
     let _guard = config::logging::configure_tracing()?;
 
     HttpServer::new(|| App::new().wrap(TracingLogger::default()).service(root))
-        .bind((config::server::get_host(), config::server::get_port()))?
+        .bind((
+            config::server::get_host().as_ref(),
+            config::server::get_port(),
+        ))?
         .run()
         .await?;
 


### PR DESCRIPTION
The hostname resolution function previously made an unnecessary allocation when falling back to the default host name. This wraps the default hostname in a `Cow` type to resolve that