### PR TITLE
Remove conditional logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,3 @@
-[features]
-default = ["stream-logging", "file-logging"]
-stream-logging = []
-file-logging = []
-
 [package]
 name = "wormhole"
 version = "0.1.0"

--- a/src/config/logging.rs
+++ b/src/config/logging.rs
@@ -4,49 +4,61 @@ use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::prelude::*;
-use tracing_subscriber::{fmt, Registry};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::{fmt, Layer, Registry};
 
 const LOG_LEVEL_ENV_VAR: &str = "WORMHOLE_LOG_LEVEL";
 const LOG_FILE_PREFIX: &str = "log";
 const LOG_FILE_DIRECTORY: &str = "./log";
 
-pub fn configure_tracing() -> anyhow::Result<Option<WorkerGuard>> {
-    let mut _guard: Option<WorkerGuard> = None;
-    let subscriber = Registry::default();
+fn get_stdout_layer<S>() -> impl Layer<S>
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fmt::layer()
+        .event_format(tracing_subscriber::fmt::format().compact())
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+}
 
-    #[cfg(feature = "stream-logging")]
-    let subscriber = {
-        let layer = fmt::layer()
-            .event_format(tracing_subscriber::fmt::format().compact())
-            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE);
-        subscriber.with(layer)
-    };
+fn get_file_layer<S>() -> (impl Layer<S>, WorkerGuard)
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    let file_appender = tracing_appender::rolling::hourly(LOG_FILE_PREFIX, LOG_FILE_DIRECTORY);
+    let (file_writer, worker_guard) = tracing_appender::non_blocking(file_appender);
 
-    #[cfg(feature = "file-logging")]
-    let subscriber = {
-        let file_appender = tracing_appender::rolling::hourly(LOG_FILE_PREFIX, LOG_FILE_DIRECTORY);
-        let (file_writer, worker_guard) = tracing_appender::non_blocking(file_appender);
-        _guard = Some(worker_guard);
-        let layer = fmt::layer()
-            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
-            .with_writer(file_writer);
-        subscriber.with(layer)
-    };
+    let layer = fmt::layer()
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+        .with_writer(file_writer);
+
+    (layer, worker_guard)
+}
+
+fn get_env_filter_layer<S>() -> impl Layer<S>
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
     let default_level_filter = if cfg!(debug_assertions) {
         LevelFilter::DEBUG
     } else {
         LevelFilter::INFO
     };
 
-    let env_filter = EnvFilter::builder()
+    EnvFilter::builder()
         .with_default_directive(default_level_filter.into())
         .with_env_var(LOG_LEVEL_ENV_VAR)
-        .from_env_lossy();
+        .from_env_lossy()
+}
 
-    let subscriber = subscriber.with(env_filter);
+pub fn configure_tracing() -> anyhow::Result<WorkerGuard> {
+    let (file_layer, worker_guard) = get_file_layer();
+    let subscriber = Registry::default()
+        .with(get_stdout_layer())
+        .with(file_layer)
+        .with(get_env_filter_layer());
 
     tracing::subscriber::set_global_default(subscriber)?;
 
     tracing::info!("Set up logging subscriber");
-    Ok(_guard)
+    Ok(worker_guard)
 }


### PR DESCRIPTION
Logging was previously set up with conditional compilation, but after thinking about it more it really felt like we probably wanted to keep logging on in general, and if we didn't conditional compilation was probably not the correct way to disable it anyway.

This change removes the conditional compilation and organizes layer creation a little bit