### PR TITLE
Move HTTP API endpoint paths behind versioned path slug

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,47 @@
 mod config;
-use actix_web::{get, App, HttpServer, Responder};
+use actix_web::{web, App, HttpServer, Responder};
 use anyhow::Result as AnyhowResult;
 use tracing_actix_web::TracingLogger;
 
-#[get("/")]
-async fn root() -> impl Responder {
+async fn api_root() -> impl Responder {
     "I am root"
+}
+
+fn configure_api_scope(cfg: &mut web::ServiceConfig) {
+    cfg.service(web::resource("/").route(web::get().to(api_root)));
 }
 
 #[tokio::main]
 async fn main() -> AnyhowResult<()> {
     let _guard = config::logging::configure_tracing()?;
 
-    HttpServer::new(|| App::new().wrap(TracingLogger::default()).service(root))
-        .bind((
-            config::server::get_host().as_ref(),
-            config::server::get_port(),
-        ))?
-        .run()
-        .await?;
+    HttpServer::new(|| {
+        App::new().service(
+            web::scope("api/v1")
+                .wrap(TracingLogger::default())
+                .configure(configure_api_scope),
+        )
+    })
+    .bind((
+        config::server::get_host().as_ref(),
+        config::server::get_port(),
+    ))?
+    .run()
+    .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{http, test};
+
+    #[actix_web::test]
+    async fn test_get_api_v1_root_is_ok() {
+        let req = test::TestRequest::default().to_http_request();
+        let responder = api_root().await;
+        let response = responder.respond_to(&req);
+        assert_eq!(response.status(), http::StatusCode::OK);
+    }
 }


### PR DESCRIPTION
Moves endpoints for handling the HTTP API endpoint to a scoped service that prefixes them with `api/v1`.

This means that HTTP requests to our server will go through:

```
https://<host>/api/v1/<whatever>
```

This will come in handy later for namespacing our HTTP requests when we add WS routes to the server.