### PR TITLE
[Logging] More logging tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,6 +1265,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,12 +1284,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ tracing = "0.1.37"
 tracing-actix-web = "0.7.5"
 tracing-appender = "0.2.2"
 tracing-core = "0.1.31"
-tracing-subscriber = { version = "0.3.17", features = ["std", "fmt", "env-filter"] }
+tracing-subscriber = { version = "0.3.17", features = ["std", "fmt", "env-filter", "json"] }
 uuid = { version = "1.3.4", features = ["v4", "fast-rng"] }

--- a/src/config/logging.rs
+++ b/src/config/logging.rs
@@ -16,8 +16,7 @@ where
     S: tracing::Subscriber + for<'a> LookupSpan<'a>,
 {
     fmt::layer()
-        .event_format(tracing_subscriber::fmt::format().compact())
-        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+        .event_format(tracing_subscriber::fmt::format().pretty())
 }
 
 fn get_file_layer<S>() -> (impl Layer<S>, WorkerGuard)
@@ -29,7 +28,8 @@ where
 
     let layer = fmt::layer()
         .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
-        .with_writer(file_writer);
+        .with_writer(file_writer)
+        .json();
 
     (layer, worker_guard)
 }


### PR DESCRIPTION
This change makes a couple of tweaks to logging:
- Removes span open / close events from stdout logging.
  - They are a little noisy and make reading the log output a little more difficult. The events will remain in the persisted log file however.
- Uses "Pretty" formatting for stdout logs
  - Since these are primarily intended for local development / debugging I updated the formatter to pretty print the log messages to make them a little easier on the eyes
- Uses JSON formatting for logfile logs
  - JSON formatting in the logfile logs will allow for easier processing / displaying of the logs down the road