### PR TITLE
[Rooms] Add room deletion cleanup job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,10 +495,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
 
 [[package]]
 name = "futures-sink"
@@ -518,10 +571,16 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1523,6 +1582,7 @@ dependencies = [
  "actix-web",
  "actix-web-actors",
  "anyhow",
+ "futures",
  "serde",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ actix = "0.13.0"
 actix-web = "4.3.1"
 actix-web-actors = "4.2.0"
 anyhow = "1.0.71"
+futures = "0.3.28"
 serde = { version = "1.0.163", features = ["derive"] }
 thiserror = "1.0.40"
 tokio = { version = "1.28.2", features = ["full"] }

--- a/src/config/logging.rs
+++ b/src/config/logging.rs
@@ -15,8 +15,7 @@ fn get_stdout_layer<S>() -> impl Layer<S>
 where
     S: tracing::Subscriber + for<'a> LookupSpan<'a>,
 {
-    fmt::layer()
-        .event_format(tracing_subscriber::fmt::format().pretty())
+    fmt::layer().event_format(tracing_subscriber::fmt::format().pretty())
 }
 
 fn get_file_layer<S>() -> (impl Layer<S>, WorkerGuard)

--- a/src/config/logging.rs
+++ b/src/config/logging.rs
@@ -7,10 +7,14 @@ use tracing_subscriber::prelude::*;
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::{fmt, Layer, Registry};
 
+/// The name of the environment variable that can be set to override the default log level
 const LOG_LEVEL_ENV_VAR: &str = "WORMHOLE_LOG_LEVEL";
+/// The prefix appended to the generated log files
 const LOG_FILE_PREFIX: &str = "log";
+/// Project relative directory where log files are created
 const LOG_FILE_DIRECTORY: &str = "./log";
 
+#[doc(hidden)]
 fn get_stdout_layer<S>() -> impl Layer<S>
 where
     S: tracing::Subscriber + for<'a> LookupSpan<'a>,
@@ -18,6 +22,7 @@ where
     fmt::layer().event_format(tracing_subscriber::fmt::format().pretty())
 }
 
+#[doc(hidden)]
 fn get_file_layer<S>() -> (impl Layer<S>, WorkerGuard)
 where
     S: tracing::Subscriber + for<'a> LookupSpan<'a>,
@@ -33,6 +38,7 @@ where
     (layer, worker_guard)
 }
 
+#[doc(hidden)]
 fn get_env_filter_layer<S>() -> impl Layer<S>
 where
     S: tracing::Subscriber + for<'a> LookupSpan<'a>,
@@ -49,6 +55,9 @@ where
         .from_env_lossy()
 }
 
+/// Configures a tracing subscriber and registers it in the global project scope
+/// This returns a guard value that flushes the filewriter buffer when dropped, which should be
+/// retained for the duration of the program.
 pub fn configure_tracing() -> anyhow::Result<WorkerGuard> {
     let (file_layer, worker_guard) = get_file_layer();
     let subscriber = Registry::default()

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -1,11 +1,20 @@
+//! Values and utility functions for configuring the server
+
 use std::{borrow::Cow, env::var};
 use tracing::info;
 
+/// The name of the environment variable that can be used to override the host
 const HOST_ENV_VAR: &str = "WORMHOLE_HOST";
+/// The name of the environment variable that can be used to override the port
 const PORT_ENV_VAR: &str = "WORMHOLE_PORT";
+/// The default host that the server is configured to use
 const DEFAULT_HOST: &str = "127.0.0.1";
+/// The default port that the server is configured to use
 const DEFAULT_PORT: u16 = 8080;
 
+/// Gets the server host name.
+/// Reads from the [environment][HOST_ENV_VAR] if available, otherwise falls back to the [default
+/// value][DEFAULT_HOST]
 pub fn get_host() -> Cow<'static, str> {
     match var(HOST_ENV_VAR) {
         Ok(host) => {
@@ -19,6 +28,9 @@ pub fn get_host() -> Cow<'static, str> {
     }
 }
 
+/// Gets the server port.
+/// Reads from the [environment][PORT_ENV_VAR] if available, otherwise falls back to the [default
+/// value][DEFAULT_PORT]
 pub fn get_port() -> u16 {
     match var(PORT_ENV_VAR) {
         Ok(port) => {

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,7 +1,9 @@
 mod player;
 mod room;
+mod room_deletion_handler;
 mod room_registry;
 
 pub(crate) use player::*;
 pub(crate) use room::*;
+pub(crate) use room_deletion_handler::*;
 pub(crate) use room_registry::*;

--- a/src/game/player.rs
+++ b/src/game/player.rs
@@ -1,5 +1,8 @@
+//! Houses functionality related to player sessions
+
 use std::hash::Hash;
 #[derive(Debug, Hash, PartialOrd, Eq, PartialEq, Copy, Clone)]
+/// Id type that uniquely identifies a player
 pub(crate) struct PlayerId(u128);
 
 impl From<u128> for PlayerId {
@@ -9,6 +12,7 @@ impl From<u128> for PlayerId {
 }
 
 #[derive(Debug, Eq)]
+/// A player in a room
 pub(crate) struct Player {
     id: PlayerId,
 }

--- a/src/game/room.rs
+++ b/src/game/room.rs
@@ -1,18 +1,72 @@
 use std::collections::HashSet;
 
-use crate::game::Player;
+use tokio::sync::mpsc::Sender;
+use tokio::task::{spawn, JoinHandle};
+use tokio::time;
+use tracing::{info, instrument, warn};
+
+use crate::game::{Player, RoomId};
+
+const DEFAULT_DELETION_TIMEOUT_SECONDS: u64 = 30;
 
 /// A room is an entity that maintains a collection of [players][Player]
 /// and is responsible for orchestrating their interactions
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub(crate) struct Room {
+    id: RoomId,
+    deletion_channel: Sender<RoomId>,
+    deletion_handle: Option<JoinHandle<()>>,
     players: HashSet<Player>,
 }
 
+impl PartialEq for Room {
+    fn eq(&self, other: &Self) -> bool {
+        self.id.eq(&other.id)
+    }
+}
+
 impl Room {
-    pub fn new() -> Self {
-        Self {
+    pub fn new(id: RoomId, deletion_channel: Sender<RoomId>) -> Self {
+        let mut this = Self {
+            id,
+            deletion_channel,
+            deletion_handle: None,
             players: Default::default(),
+        };
+
+        this.schedule_deletion();
+
+        this
+    }
+
+    #[instrument(skip_all)]
+    fn schedule_deletion(&mut self) {
+        info!(event = "scheduling_deletion", room_id = %self.id);
+        let deletion_channel = self.deletion_channel.clone();
+        let id = self.id.clone();
+        let handle = spawn(async move {
+            time::sleep(time::Duration::from_secs(DEFAULT_DELETION_TIMEOUT_SECONDS)).await;
+
+            info!(event = "requesting_deletion", room_id = %id);
+            let res = deletion_channel.send(id).await;
+            info!(event = "deletion_request_result", res = ?res);
+        });
+
+        self.deletion_handle = Some(handle);
+    }
+
+    #[instrument(skip_all)]
+    fn cancel_deletion(&mut self) {
+        match &self.deletion_handle {
+            None => {
+                warn!(event = "cancel_deletion_task.invalid", room_id = %self.id)
+            }
+            Some(handle) => {
+                info!(event = "cancel_deletion_task.valid", room_id = %self.id);
+                handle.abort();
+            }
         }
+
+        self.deletion_handle = None;
     }
 }

--- a/src/game/room_deletion_handler.rs
+++ b/src/game/room_deletion_handler.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use tokio::sync::mpsc::{self, Receiver, Sender};
+
+use crate::game::{RoomId, RoomRegistry};
+
+const DEFAULT_DELETION_CHANNEL_BUFFER_SIZE: usize = 100;
+
+pub(crate) struct RoomDeletionHandler {
+    registry_mutex: Arc<Mutex<RoomRegistry>>,
+    receiver: Receiver<RoomId>,
+}
+
+impl RoomDeletionHandler {
+    pub fn new_with_registry(registry_mutex: Arc<Mutex<RoomRegistry>>) -> (Self, Sender<RoomId>) {
+        let (sender, receiver) = mpsc::channel::<RoomId>(DEFAULT_DELETION_CHANNEL_BUFFER_SIZE);
+
+        let handler = Self {
+            receiver,
+            registry_mutex,
+        };
+
+        (handler, sender)
+    }
+
+    pub async fn watch(&mut self) {
+        while let Some(room_id) = &self.receiver.recv().await {
+            let mut registry = self.registry_mutex.lock().unwrap();
+            registry.delete_room(room_id);
+        }
+    }
+}

--- a/src/game/room_deletion_handler.rs
+++ b/src/game/room_deletion_handler.rs
@@ -1,3 +1,5 @@
+//! Houses utilities related to orchestrating automatic idle room cleanup
+
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -5,14 +7,18 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 
 use crate::game::{RoomId, RoomRegistry};
 
+/// The number of room deletion messages that can sit in the room deletion channel before sending
+/// on it becomes blocking
 const DEFAULT_DELETION_CHANNEL_BUFFER_SIZE: usize = 100;
 
+/// Cleans up rooms within a given registry when their IDs are sent over the provided channel
 pub(crate) struct RoomDeletionHandler {
     registry_mutex: Arc<Mutex<RoomRegistry>>,
     receiver: Receiver<RoomId>,
 }
 
 impl RoomDeletionHandler {
+    /// Creates a new deletion handler for a provided [registry][RoomRegistry]
     pub fn new_with_registry(registry_mutex: Arc<Mutex<RoomRegistry>>) -> (Self, Sender<RoomId>) {
         let (sender, receiver) = mpsc::channel::<RoomId>(DEFAULT_DELETION_CHANNEL_BUFFER_SIZE);
 
@@ -24,6 +30,7 @@ impl RoomDeletionHandler {
         (handler, sender)
     }
 
+    /// Begins watching for and handling room deletion requests
     pub async fn watch(&mut self) {
         while let Some(room_id) = &self.receiver.recv().await {
             let mut registry = self.registry_mutex.lock().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,17 +3,27 @@ mod game;
 
 use std::sync::Mutex;
 
-use crate::game::RoomRegistry;
-
 use actix_web::{body::BoxBody, web, App, HttpResponse, HttpServer};
 use anyhow::Result as AnyhowResult;
+use tokio::sync::mpsc::Sender;
 use tracing_actix_web::TracingLogger;
 
-async fn create_room(state: web::Data<SharedAppState>) -> HttpResponse {
+use crate::game::{RoomDeletionHandler, RoomId, RoomRegistry};
+
+async fn get_rooms(registry: web::Data<Mutex<RoomRegistry>>) -> web::Json<Vec<String>> {
+    let mut room_registry = registry.lock().unwrap();
+    let room_ids = room_registry.list_active_rooms();
+    web::Json(room_ids)
+}
+
+async fn create_room(
+    registry: web::Data<Mutex<RoomRegistry>>,
+    sender: web::Data<Sender<RoomId>>,
+) -> HttpResponse {
     // TODO (mitch): Graceful handling of lock acquisition
     // https://github.com/alexrkoch/wormhole-server/issues/10
-    let mut room_registry = state.room_registry.lock().unwrap();
-    let create_room_result = room_registry.create_room();
+    let mut room_registry = registry.lock().unwrap();
+    let create_room_result = room_registry.create_room(sender.get_ref().clone());
 
     match create_room_result {
         Err(e) => HttpResponse::InternalServerError()
@@ -26,33 +36,41 @@ async fn create_room(state: web::Data<SharedAppState>) -> HttpResponse {
 }
 
 fn configure_api_scope(cfg: &mut web::ServiceConfig) {
-    cfg.service(web::resource("/rooms/").route(web::post().to(create_room)));
-}
-
-struct SharedAppState {
-    room_registry: Mutex<RoomRegistry>,
+    cfg.service(
+        web::resource("/rooms/")
+            .route(web::post().to(create_room))
+            .route(web::get().to(get_rooms)),
+    );
 }
 
 #[tokio::main]
 async fn main() -> AnyhowResult<()> {
     let _guard = config::logging::configure_tracing()?;
-    let state = web::Data::new(SharedAppState {
-        room_registry: Mutex::new(RoomRegistry::new()),
-    });
+    let room_registry = web::Data::new(Mutex::new(RoomRegistry::new()));
 
-    HttpServer::new(move || {
-        App::new().app_data(state.clone()).service(
-            web::scope("api/v1")
-                .wrap(TracingLogger::default())
-                .configure(configure_api_scope),
-        )
+    let (mut handler, sender) =
+        RoomDeletionHandler::new_with_registry(room_registry.clone().into_inner());
+    let sender = web::Data::new(sender);
+
+    let room_deletion_handle = handler.watch();
+
+    let server_handle = HttpServer::new(move || {
+        App::new()
+            .app_data(room_registry.clone())
+            .app_data(sender.clone())
+            .service(
+                web::scope("api/v1")
+                    .wrap(TracingLogger::default())
+                    .configure(configure_api_scope),
+            )
     })
     .bind((
         config::server::get_host().as_ref(),
         config::server::get_port(),
     ))?
-    .run()
-    .await?;
+    .run();
+
+    futures::join!(room_deletion_handle, server_handle);
 
     Ok(())
 }


### PR DESCRIPTION
When rooms are created a task is created to request their deletion at a point in the future. Currently the timeout is 30 seconds.

In the future when there are mechanisms to enable players to join the room we will want to cancel the task and then reschedule it in the event that all players have left the room and it is empty